### PR TITLE
Uncommenting 2 lines in the data.py script resolved the error message…

### DIFF
--- a/avae/data.py
+++ b/avae/data.py
@@ -327,13 +327,13 @@ class Dataset_reader(Dataset):     # this is a custom torch dataset
         # file info and metadata
         meta = "_".join(filename.split(".")[0].split("_")[1:])              # creating a dataframe to downstream analysis
         avg = np.around(np.average(x), decimals=4)
-        img = format(x, len(data.shape))  # used for dynamic preview in Altair
+        # img = format(x, len(data.shape))  # used for dynamic preview in Altair ## EP commenting out as raises error with omics data
         meta = {
             "filename": filename,
             "id": y,
             "meta": meta,
             "avg": avg,
-            "image": img,
+            # "image": img,          ## commenting out for now as raises error with omics data
         }
         return x, y, aff, meta
 


### PR DESCRIPTION
Commenting out 2 lines in the data.py file that remove the error "WARNING: Wrong data format, please pass either a single "
            "unsqueezed tensor or a batch to image formatter. Exiting."

This error comes from the format function in vis.py and relates to  image formatting and not required for omics data.